### PR TITLE
Fix subtraction coercions

### DIFF
--- a/lib/ruby-cbc.rb
+++ b/lib/ruby-cbc.rb
@@ -9,6 +9,7 @@ files = %w(
   model
   problem
   version
+  ilp/constant
   ilp/constraint
   ilp/objective
   ilp/term

--- a/lib/ruby-cbc/ilp/constant.rb
+++ b/lib/ruby-cbc/ilp/constant.rb
@@ -1,0 +1,49 @@
+module Ilp
+  class Constant
+    attr_accessor :value
+    def initialize(value)
+      raise ArgumentError, "Argument is not numeric" unless value.is_a? Numeric
+      @value = value
+    end
+
+    def <=(other)
+      other >= value
+    end
+
+    def <(other)
+      other > value
+    end
+
+    def >=(other)
+      other <= value
+    end
+
+    def >(other)
+      other < value
+    end
+
+    def ==(other)
+      other == value
+    end
+
+    def *(other)
+      other * value
+    end
+
+    def +(other)
+      other + value
+    end
+
+    def -(other)
+      -1 * other + value
+    end
+
+    def to_s
+      value.to_s
+    end
+
+    def pretty_print
+      value.to_s
+    end
+  end
+end

--- a/lib/ruby-cbc/ilp/constraint.rb
+++ b/lib/ruby-cbc/ilp/constraint.rb
@@ -4,8 +4,7 @@ module Ilp
     GREATER_OR_EQ = :greater_or_eq
     EQUALS = :equals
 
-    attr_reader :terms, :type, :bound
-    attr_accessor :function_name
+    attr_accessor :terms, :type, :bound, :function_name
 
     def initialize(terms, type, bound)
       @terms = terms - bound

--- a/lib/ruby-cbc/ilp/objective.rb
+++ b/lib/ruby-cbc/ilp/objective.rb
@@ -3,7 +3,7 @@ module Ilp
     MINIMIZE = :min
     MAXIMIZE = :max
 
-    attr_reader :terms, :objective_function
+    attr_accessor :terms, :objective_function
     def initialize(terms, objective_function = MAXIMIZE)
       @terms = terms
       @terms = Ilp::Term.new(@terms) if @terms.is_a? Ilp::Var

--- a/lib/ruby-cbc/ilp/term.rb
+++ b/lib/ruby-cbc/ilp/term.rb
@@ -1,7 +1,6 @@
 module Ilp
   class Term
-    attr_reader :var
-    attr_accessor :mult
+    attr_accessor :mult, :var
 
     def initialize(var, mult = 1)
       @mult = mult
@@ -26,13 +25,6 @@ module Ilp
 
     def >=(other)
       Ilp::TermArray.new([self]) >= other
-    end
-
-    def combine_in(other_term)
-      return Term.new(var, mult) unless other_term
-      raise "Terms cannot be combined: #{self} and #{other_term}" unless var.equal? other_term.var
-      other_term.mult += mult
-      other_term
     end
 
     def *(other)

--- a/lib/ruby-cbc/ilp/term.rb
+++ b/lib/ruby-cbc/ilp/term.rb
@@ -33,7 +33,7 @@ module Ilp
     end
 
     def coerce(num)
-      [Ilp::TermArray.new([self]), num]
+      [Ilp::Constant.new(num), Ilp::TermArray.new([self])]
     end
 
     def to_s

--- a/lib/ruby-cbc/ilp/term_array.rb
+++ b/lib/ruby-cbc/ilp/term_array.rb
@@ -2,7 +2,7 @@ module Ilp
   class TermArray
     extend Forwardable
 
-    attr_reader :terms
+    attr_accessor :terms
     def_delegators :@terms, :map, :each, :size
 
     def initialize(terms)
@@ -45,8 +45,9 @@ module Ilp
         when Numeric
           constant += term
         when Ilp::Term
-          variable = term.var
-          hterms[variable] = term.combine_in(hterms[variable])
+          v = term.var
+          hterms[v] ||= Ilp::Term.new(v, 0)
+          hterms[v].mult += term.mult
         end
       end
       reduced = hterms.map { |_, term| term unless term.mult.zero? }
@@ -68,7 +69,7 @@ module Ilp
     end
 
     def coerce(value)
-      [value, self]
+      [Ilp::Constant.new(value), self]
     end
 
     def to_s

--- a/lib/ruby-cbc/ilp/var.rb
+++ b/lib/ruby-cbc/ilp/var.rb
@@ -52,7 +52,7 @@ module Ilp
     end
 
     def coerce(num)
-      [Ilp::Term.new(self), num]
+      [Ilp::Constant.new(num), self]
     end
 
     def to_s

--- a/spec/term_and_var_spec.rb
+++ b/spec/term_and_var_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe "Terms and vars" do
+  let(:model) { Cbc::Model.new }
+  let(:x) { model.int_var(name: 'x') }
+  let(:y) { model.int_var(name: 'y') }
+  let(:problem) { model.to_problem }
+
+  ## Assertions...
+
+  def objective?(expected)
+    expect(model.objective.to_s.gsub(/\s+/, ' ').strip).to eq(expected)
+  end
+
+  def constraints?(*expected)
+    expect(model.constraints.map(&:to_s)).to match_array(expected)
+  end
+
+  def optimal?(h)
+    problem.solve
+    expect(problem).to be_proven_optimal
+
+    h.each do |var, expected_value|
+      expect(problem.value_of(var)).to eq(expected_value)
+    end
+  end
+
+  specify "var + var" do
+    model.enforce(x + y <= 4)
+    model.maximize(x)
+
+    objective? "Maximize + x"
+    optimal? x => 4, y => 0
+  end
+
+  specify "var + const" do
+    model.enforce(x + 2 <= 4)
+    model.maximize x
+
+    objective? "Maximize + x"
+    constraints? "+ x <= 2"
+    optimal? x => 2
+  end
+
+  specify "const + var" do
+    model.enforce(2 + x <= 4)
+    model.maximize x
+
+    objective? "Maximize + x"
+    constraints? "+ x <= 2"
+    optimal? x => 2
+  end
+
+  specify "var - var" do
+    model.enforce(x - y <= 4)
+    model.minimize(x)
+
+    objective? "Minimize + x"
+    optimal? x => 0, y => 0
+  end
+
+  specify "var - const" do
+    model.enforce(x - 2 <= 4)
+    model.maximize x
+
+    objective? "Maximize + x"
+    constraints? "+ x <= 6"
+    optimal? x => 6
+  end
+
+  specify "const - var" do
+    model.enforce(2 - x <= 4)
+    model.minimize x
+
+    objective? "Minimize + x"
+    constraints? "- 1 x <= 2"
+    optimal? x => 0
+  end
+
+  specify "-var" do
+    model.maximize(-x)
+
+    objective? "Maximize - 1 x"
+    optimal? x => 0
+  end
+
+  specify "var * const" do
+    model.maximize(x * -3)
+
+    objective? "Maximize - 3 x"
+    optimal? x => 0
+  end
+
+  specify "const * var" do
+    model.maximize(-3 * x)
+
+    objective? "Maximize - 3 x"
+    optimal? x => 0
+  end
+
+  describe "Constraints" do
+    specify "var + const <= const" do
+      expect((x + 3 <= 14).to_s).to eq("+ x <= 11")
+    end
+
+    specify "var - const <= const" do
+      expect((x - 3 <= 14).to_s).to eq("+ x <= 17")
+    end
+
+    specify "const + var <= const" do
+      expect((3 + x <= 14).to_s).to eq("+ x <= 11")
+    end
+
+    specify "const - var <= const" do
+      expect((3 - x <= 14).to_s).to eq("- 1 x <= 11")
+    end
+
+    specify "const - term <= const" do
+      expect((3 - (4*x) <= 14).to_s).to eq("- 4 x <= 11")
+    end
+
+    specify "const - termarray <= const" do
+      expect((3 - (4 * x + 4) <= 14).to_s).to eq('- 4 x <= 15')
+    end
+  end
+
+end


### PR DESCRIPTION
The current implementations of several of ruby-cbc's `coerce` methods return `self` in the first position, which causes problems with non-commutative operations (in particular, subtraction). 

For example, consider:

```ruby
x = Ilp::Var.new(name: 'x')
y = 3 - x
```

`Ilp::Var#coerce` is defined as follows:

```ruby
def coerce(num)
  [Ilp::Term.new(self), num]
end
```

Which means that the subtraction gets converted into the equivalent of `Ilp::Term.new(x) - 3`, the opposite of what y is supposed to be.

Since we can't return `num` itself because that would cause an infinite loop, my fix involves restoring `Ilp::Constant` and using it to tag constant values in the head position. Since Constant knows how to subtract terms and term arrays from itself, this restores the correct behavior of coercion.

Added a few specs that demonstrate the incorrect behavior and prove the fix works.

Thanks!
Brad